### PR TITLE
Handle content-type of x-www-form-urlencoded

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,14 @@
 const cj = require('color-json');
+const hasOwnProperty = (object, property) => Object.prototype.hasOwnProperty.call(object, property);
+
+module.exports = curlString;
 
 /**
  * Builds a curl command and returns the string.
- * @param  {String} url     Endpoint
- * @param  {Object} options Object with headers, etc. (fetch format)
- * @return {String}         Curl command
+ * @param  {String} url               Endpoint
+ * @param  {Object} options           Object with headers, etc. (fetch format)
+ * @param  {Object} [curlStringOptions={colorJson:true,jsonIndentWidth:2}] Formatting options
+ * @return {String}                   cURL command
  */
 function curlString(
   url,
@@ -33,25 +37,54 @@ function curlString(
   }
 
   if (hasBody) {
-    let parsedData;
-    try {
-      parsedData = JSON.parse(options.body);
-    } catch (e) {
-      parsedData = options.body;
-    }
-
-    const colorJson = curlStringOptions && curlStringOptions.colorJson;
-    const jsonIndentWidth =
-      (curlStringOptions && curlStringOptions.jsonIndentWidth) || 2;
-
-    curl += `\n--data '${
-      colorJson
-        ? cj(parsedData)
-        : JSON.stringify(parsedData, null, jsonIndentWidth)
-    }'`;
+    curl += `\n--data '${bodyToDataString(options, curlStringOptions)}'`
   }
 
   return curl;
 }
 
-module.exports = curlString;
+function getHeader(options, headerKeyName) {
+  return options.headers[headerKeyName];
+}
+
+function hasHeader(options, headerKeyName) {
+  return hasOwnProperty(options, 'headers') &&
+    Object.keys(options.headers)
+      .find(header => headerKeyName === header.toLowerCase());
+}
+
+/**
+ * Constructs a body string for use inside --data
+ * @param  {Object} options           Object with headers, etc. (fetch format)
+ * @param  {Object} curlStringOptions Formatting options
+ * @return {String}                   cURL command data string
+ */
+function bodyToDataString(options, curlStringOptions) {
+  let parsedData;
+  try {
+    parsedData = JSON.parse(options.body);
+  } catch (e) {
+    // fall back to original body if it could not be parsed as JSON
+    parsedData = options.body;
+  }
+
+  // return an ampersand delimited string
+  if (hasHeader(options, 'content-type') &&
+      getHeader(options, 'content-type').toLowerCase() === 'application/x-www-form-urlencoded') {
+    if (typeof parsedData === 'string') {
+      return parsedData;
+    } else {
+      return Object.entries(parsedData)
+        .map(([key, val]) => `${key}=${val}`)
+        .join('&');
+    }
+  } else {
+    const colorJson = curlStringOptions && curlStringOptions.colorJson;
+    const jsonIndentWidth =
+      (curlStringOptions && curlStringOptions.jsonIndentWidth) || 2;
+
+    return colorJson
+      ? cj(parsedData)
+      : JSON.stringify(parsedData, null, jsonIndentWidth);
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1149,9 +1149,9 @@
       }
     },
     "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.1.tgz",
+      "integrity": "sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg==",
       "dev": true,
       "optional": true
     },
@@ -2285,9 +2285,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.2.tgz",
+      "integrity": "sha512-cIv17+GhL8pHHnRJzGu2wwcthL5sb8uDKBHvZ2Dtu5s1YNt0ljbzKbamnc+gr69y7bzwQiBdr5+hOpRd5pnOdg==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curl-string",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Get human-readable cURL strings",
   "main": "index.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ const options = {
 if (debug) {
   console.log(curlString(url, options));  
 }
-// make real call here, e.g. await fetch(url, options);
+// make real call here, e.g. fetch(url, options);
 ```
 Output:  
 ![screenshot](https://imgur.com/FRlmfLR.png)

--- a/test/curlString.test.js
+++ b/test/curlString.test.js
@@ -133,3 +133,51 @@ curl --request POST \\
   "hello": "world"
 }'`);
 });
+
+test('To handle x-www-form-urlencoded content-type header and JSON body', () => {
+  expect(
+    curlString(
+      'http://example.com',
+      {
+        method: 'post',
+        headers: {
+          accept: 'application/json',
+          'accept-language': 'en',
+          'content-type': 'application/x-www-form-urlencoded'
+        },
+        body: { hello: 'world', inTheWorld: true, ofTheWorld: false }
+      },
+      { colorJson: false }
+    )
+  ).toBe(`
+curl --request POST \\
+--url http://example.com \\
+--header 'accept: application/json' \\
+--header 'accept-language: en' \\
+--header 'content-type: application/x-www-form-urlencoded' \\
+--data 'hello=world&inTheWorld=true&ofTheWorld=false'`);
+});
+
+test('To handle x-www-form-urlencoded content-type header and already URL encoded body', () => {
+  expect(
+    curlString(
+      'http://example.com',
+      {
+        method: 'post',
+        headers: {
+          accept: 'application/json',
+          'accept-language': 'en',
+          'content-type': 'application/x-www-form-urlencoded'
+        },
+        body: 'hello=world&inTheWorld=true&ofTheWorld=false'
+      },
+      { colorJson: false }
+    )
+  ).toBe(`
+curl --request POST \\
+--url http://example.com \\
+--header 'accept: application/json' \\
+--header 'accept-language: en' \\
+--header 'content-type: application/x-www-form-urlencoded' \\
+--data 'hello=world&inTheWorld=true&ofTheWorld=false'`);
+});


### PR DESCRIPTION
1.1.0

Handle additional content-type header (and its body):
`content-type: application/x-www-form-urlencoded`

See [gist](https://gist.github.com/subfuzion/08c5d85437d5d4f00e58#post-applicationx-www-form-urlencoded) for example.